### PR TITLE
Fix build failure when component has child component

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ module.exports = function compileStylus(builder) {
           .set('filename', styl)
           .use(nib());
 
-        if (pkg.parent && pkg.parent.config.build.stylus && pkg.parent.config.build.stylus.imports) {
+        if (pkg.parent && pkg.parent.config.build && pkg.parent.config.build.stylus && pkg.parent.config.build.stylus.imports) {
           pkg.parent.config.build.stylus.imports.forEach(function (path) {
             var imp = pkg.parent.dir + '/' + path;
             debug('importing: %s', imp);

--- a/test/index.js
+++ b/test/index.js
@@ -36,4 +36,14 @@ describe("Component Stylus", function () {
     });
   });
   
+  it('should build stylus in a component with child into css', function (done) {
+    var builder = new Builder(__dirname + '/support/with-child-component');
+    
+    builder.use(componentStylus);
+    
+    builder.build(function (err, res) {
+      expect(res.css).to.eql('body {\n  background: #000;\n}\n');
+      done()
+    });
+  });
 })

--- a/test/support/with-child-component/clients/child/component.json
+++ b/test/support/with-child-component/clients/child/component.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-child-component",
+  "version": "1.0.0",
+  "styles": [
+    "main.styl"
+  ]
+}

--- a/test/support/with-child-component/clients/child/main.styl
+++ b/test/support/with-child-component/clients/child/main.styl
@@ -1,0 +1,2 @@
+body
+  background: #000

--- a/test/support/with-child-component/component.json
+++ b/test/support/with-child-component/component.json
@@ -1,0 +1,10 @@
+{
+  "name": "test-component",
+  "version": "1.0.0",
+  "local":[
+    "child"
+  ],
+  "paths": [
+    "clients"
+  ]
+}


### PR DESCRIPTION
I stumbled upon the error case when the `component` has _child_ `component`.
Such case found in [example todo app](https://github.com/component/todo), whose structure looks like below:

```
├── client
│   ├── boot
│   │   ├── component.json
│   │   ├── index.js
│   │   └── style.css
│   ├── item
│   │   ├── component.json
│   │   └── index.js
│   └── item-view
│       ├── component.json
│       ├── index.js
│       ├── style.css
│       ├── template.html
│       └── template.js
├── component.json
```

and the root `component.json` looks like:

```
{
  "name": "todo",
  "description": "TodoMVC component example",
  "version": "0.0.1",
  "local": ["boot"],
  "paths": ["client"]
}
```

So I added the test case `support/with-child-component` and another check to `pkg.parent` condition to make the test pass.

Please take a look and merge it if possible ;)

Thanks.
