### PR TITLE
Pass options to stylus and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ var fs = require('fs')
 
 var builder = new Builder(__dirname);
 
-builder.use(c7tStylus);
+builder.use(c7tStylus());
 
 builder.build(function(err, res){
   if (err) throw err;
@@ -33,6 +33,6 @@ builder.build(function(err, res){
   fs.writeFileSync('public/package.css', res.css);
 });
 
-  
+
 ````
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ var fs = require('fs')
   , endsWith = require('./utils').endsWith;
 
 module.exports = function(builder) {
-  if ('function' == typeof builder.build) return compileStylus(builder);
+  if ('function' == typeof builder.build) return compileStylus(builder, {});
 
   var options = builder;
   return function (builder) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,8 +34,11 @@ function compileStylus(builder, options) {
           .set('filename', stylPath)
           .use(nib());
 
-        for(var key in options) {
+        for(var key in options.set) {
           render.set(key, options[key]);
+        }
+        for(var key in options.use) {
+          render.use(options.use[key]);
         }
 
         if (pkg.parent && pkg.parent.config.build && pkg.parent.config.build.stylus && pkg.parent.config.build.stylus.imports) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ function compileStylus(builder, options) {
           .use(nib());
 
         for(var key in options.set) {
-          render.set(key, options[key]);
+          render.set(key, options.set[key]);
         }
         for(var key in options.use) {
           render.use(options.use[key]);

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ function compileStylus(builder, options) {
 
         var render = stylus(fs.readFileSync(stylPath, 'utf-8'))
           .set('include css', true)
-          .set('filename', stylPath);
+          .set('filename', stylPath)
           .use(nib());
 
         for(var key in options) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,49 +5,55 @@ var fs = require('fs')
   , nib = require('nib')
   , endsWith = require('./utils').endsWith;
 
-module.exports = function compileStylus(builder) {
+module.exports = function(options) {
+  return function compileStylus(builder) {
 
-  builder.hook('before styles', function (pkg, cb) {
-    if (!pkg.config.styles) return cb();
+    builder.hook('before styles', function (pkg, cb) {
+      if (!pkg.config.styles) return cb();
 
-    var stylusFiles = pkg.config.styles.filter(endsWith('styl'))
-      , batch = new Batch();
+      var stylusFiles = pkg.config.styles.filter(endsWith('styl'))
+        , batch = new Batch();
 
-    stylusFiles.forEach(function (styl) {
-      batch.push(function (done) {
-        var stylPath = pkg.path(styl)
-          , name = styl.split('.')[0] + '.css';
+      stylusFiles.forEach(function (styl) {
+        batch.push(function (done) {
+          var stylPath = pkg.path(styl)
+            , name = styl.split('.')[0] + '.css';
 
-        debug('compiling: %s', styl);
+          debug('compiling: %s', styl);
 
-        var render = stylus(fs.readFileSync(stylPath, 'utf-8'))
-          .set('include css', true)
-          .set('filename', stylPath)
-          .use(nib());
+          var render = stylus(fs.readFileSync(stylPath, 'utf-8'))
+            .set('include css', true)
+            .set('filename', stylPath);
 
-        if (pkg.parent && pkg.parent.config.build && pkg.parent.config.build.stylus && pkg.parent.config.build.stylus.imports) {
-          pkg.parent.config.build.stylus.imports.forEach(function (path) {
-            var imp = pkg.parent.dir + '/' + path;
-            debug('importing: %s', imp);
-            
-            render.import(imp);
+          for(var key in options) {
+            render.set(key, options[key]);
+          }
+          render.use(nib());
+
+          if (pkg.parent && pkg.parent.config.build && pkg.parent.config.build.stylus && pkg.parent.config.build.stylus.imports) {
+            pkg.parent.config.build.stylus.imports.forEach(function (path) {
+              var imp = pkg.parent.dir + '/' + path;
+              debug('importing: %s', imp);
+
+              render.import(imp);
+            });
+          };
+
+          render.render(function (err, css) {
+
+            if (err) return done(err);
+
+            pkg.addFile('styles', name, css);
+            pkg.removeFile('styles', styl);
+
+            done();
           });
-        };
 
-        render.render(function (err, css) {
-
-          if (err) return done(err);
-
-          pkg.addFile('styles', name, css);
-          pkg.removeFile('styles', styl);
-      
-          done();
         });
-
       });
-    });
 
-    batch.end(cb);
-  });
+      batch.end(cb);
+    });
+  }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,55 +5,62 @@ var fs = require('fs')
   , nib = require('nib')
   , endsWith = require('./utils').endsWith;
 
-module.exports = function(options) {
-  return function compileStylus(builder) {
+module.exports = function(builder) {
+  if ('function' == typeof builder.build) return compileStylus(builder);
 
-    builder.hook('before styles', function (pkg, cb) {
-      if (!pkg.config.styles) return cb();
+  var options = builder;
+  return function (builder) {
+    compileStylus(builder, options);
+  };
+};
 
-      var stylusFiles = pkg.config.styles.filter(endsWith('styl'))
-        , batch = new Batch();
 
-      stylusFiles.forEach(function (styl) {
-        batch.push(function (done) {
-          var stylPath = pkg.path(styl)
-            , name = styl.split('.')[0] + '.css';
+function compileStylus(builder, options) {
+  builder.hook('before styles', function (pkg, cb) {
+    if (!pkg.config.styles) return cb();
 
-          debug('compiling: %s', styl);
+    var stylusFiles = pkg.config.styles.filter(endsWith('styl'))
+      , batch = new Batch();
 
-          var render = stylus(fs.readFileSync(stylPath, 'utf-8'))
-            .set('include css', true)
-            .set('filename', stylPath);
+    stylusFiles.forEach(function (styl) {
+      batch.push(function (done) {
+        var stylPath = pkg.path(styl)
+          , name = styl.split('.')[0] + '.css';
 
-          for(var key in options) {
-            render.set(key, options[key]);
-          }
-          render.use(nib());
+        debug('compiling: %s', styl);
 
-          if (pkg.parent && pkg.parent.config.build && pkg.parent.config.build.stylus && pkg.parent.config.build.stylus.imports) {
-            pkg.parent.config.build.stylus.imports.forEach(function (path) {
-              var imp = pkg.parent.dir + '/' + path;
-              debug('importing: %s', imp);
+        var render = stylus(fs.readFileSync(stylPath, 'utf-8'))
+          .set('include css', true)
+          .set('filename', stylPath);
+          .use(nib());
 
-              render.import(imp);
-            });
-          };
+        for(var key in options) {
+          render.set(key, options[key]);
+        }
 
-          render.render(function (err, css) {
+        if (pkg.parent && pkg.parent.config.build && pkg.parent.config.build.stylus && pkg.parent.config.build.stylus.imports) {
+          pkg.parent.config.build.stylus.imports.forEach(function (path) {
+            var imp = pkg.parent.dir + '/' + path;
+            debug('importing: %s', imp);
 
-            if (err) return done(err);
-
-            pkg.addFile('styles', name, css);
-            pkg.removeFile('styles', styl);
-
-            done();
+            render.import(imp);
           });
+        };
 
+        render.render(function (err, css) {
+
+          if (err) return done(err);
+
+          pkg.addFile('styles', name, css);
+          pkg.removeFile('styles', styl);
+
+          done();
         });
-      });
 
-      batch.end(cb);
+      });
     });
-  }
+
+    batch.end(cb);
+  });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-stylus",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Transpiles stylus for component",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "nib": "~0.9.1",
-    "stylus": "~0.32.0",
+    "nib": "~1.0.1",
+    "stylus": "~0.37.0",
     "debug": "~0.7.0",
     "batch": "~0.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-stylus",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Transpiles stylus for component",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This update allows passing options to stylus (anything that can be used with `stylus.set`).
We use this to enable compression with `c7stylus({compress: true})`.

Dependencies have been updated to better support newer nib mixins.
